### PR TITLE
Fix Issue #7 (close the db handle after use)

### DIFF
--- a/taskwarrior-androidapp/src/org/svij/taskwarriorapp/MenuListFragment.java
+++ b/taskwarrior-androidapp/src/org/svij/taskwarriorapp/MenuListFragment.java
@@ -117,6 +117,7 @@ public class MenuListFragment extends SherlockListFragment {
 				.getSupportFragmentManager().findFragmentById(
 						android.R.id.content);
 		listFragment.setListAdapter(adapter);
+		datasource.close();
 	}
 
 	public String getColumn() {


### PR DESCRIPTION
After the change, MenuListFragment.setTaskList() always manages to take the lock. 
Fixes https://github.com/svijee/taskwarrior-androidapp/issues/7
