### PR TITLE
In TaskAdd: Align date and time widgets. Make project single line TextEdit.

### DIFF
--- a/taskwarrior-androidapp/res/layout/activity_task_add.xml
+++ b/taskwarrior-androidapp/res/layout/activity_task_add.xml
@@ -11,7 +11,7 @@
 
         <TextView
             android:id="@+id/tvTaskDescription"
-            android:layout_width="wrap_content"
+            android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
             android:text="@string/tvTaskDescription"
@@ -32,7 +32,7 @@
 
         <TextView
             android:id="@+id/tvDueDateStatic"
-            android:layout_width="wrap_content"
+            android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
             android:layout_below="@+id/etTaskAdd"
@@ -42,26 +42,25 @@
         <TextView
             android:id="@+id/tvDueDate"
             style="@style/Dropdown.TextView"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
             android:layout_below="@+id/tvDueDateStatic"
-            android:gravity="center"
+            android:layout_toLeftOf="@+id/tvDueTime"
             android:hint="@string/setDate" />
 
         <TextView
             android:id="@+id/tvDueTime"
             style="@style/Dropdown.TextView"
-            android:layout_width="match_parent"
+            android:layout_width="96dp"
             android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_below="@+id/tvDueDate"
-            android:gravity="center"
+            android:layout_alignParentRight="true"
+            android:layout_below="@+id/tvDueDateStatic"
             android:hint="@string/setTime" />
 
         <TextView
             android:id="@+id/tvProjectStatic"
-            android:layout_width="wrap_content"
+            android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
             android:layout_below="@+id/tvDueTime"
@@ -74,11 +73,12 @@
             android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
             android:layout_below="@+id/tvProjectStatic"
-            android:hint="@string/setProject" />
+            android:hint="@string/setProject"
+            android:singleLine="true" />
 
         <TextView
             android:id="@+id/tvPriorityStatic"
-            android:layout_width="wrap_content"
+            android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
             android:layout_below="@+id/etProject"


### PR DESCRIPTION
Date and time both fit on a single horizontal line. I think it looks better horizontally and vertically (tested on a Desire Z (HTC Vision), which has a relatively small screen).

The project TextEdit is now single line. It means that pressing enter goes to the next field (Priority) instead of adding a newline.

Also, minor change, the static texts take the whole width now.

The 0dp layout_width of tvDueDate is surprising (to me at least), but has been inspired from http://developer.android.com/guide/topics/ui/layout/relative.html#Example and does the job.
